### PR TITLE
Fix container definition dependency for symfony/mercure-notifier

### DIFF
--- a/DependencyInjection/FrameworkExtension.php
+++ b/DependencyInjection/FrameworkExtension.php
@@ -2478,7 +2478,10 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', MercureTransportFactory::class, $parentPackages) && ContainerBuilder::willBeAvailable('symfony/mercure-bundle', MercureBundle::class, $parentPackages)) {
+        if (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', MercureTransportFactory::class, $parentPackages)
+            && ContainerBuilder::willBeAvailable('symfony/mercure-bundle', MercureBundle::class, $parentPackages)
+            && array_key_exists('MercureBundle',$container->getParameter('kernel.bundles'))) 
+        {
             $container->getDefinition($classToServices[MercureTransportFactory::class])
                 ->replaceArgument('$registry', new Reference(HubRegistry::class));
         } elseif (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', MercureTransportFactory::class, $parentPackages)) {


### PR DESCRIPTION
Added check if the mercure-bundle is enabled to activate framework integration